### PR TITLE
Integration with new PacktPub API endpoints

### DIFF
--- a/freepacktbook/freepacktbook.py
+++ b/freepacktbook/freepacktbook.py
@@ -5,7 +5,6 @@ import logging
 import random
 import re
 
-from bs4 import BeautifulSoup
 import requests
 from slugify import slugify
 from tqdm import tqdm

--- a/freepacktbook/freepacktbook.py
+++ b/freepacktbook/freepacktbook.py
@@ -77,8 +77,6 @@ class FreePacktBook(object):
         if not path.exists(file_path) or override:
             response = self.session.get(url, stream=True)
             total = int(response.headers.get("Content-Length", 0))
-            print(response.headers)
-            print("total", total)
             if not total:
                 return
             filename = path.split(file_path)[1]
@@ -175,7 +173,7 @@ class FreePacktBook(object):
 
     @auth_required
     def my_books(self, max_pages=10):
-        per_page = 10
+        per_page = 25
         books = []
         for page_number in range(0, max_pages):
             data = self.session.get(

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'beautifulsoup4',
         'python-slugify>=1.2.0',
         'requests',
         'tqdm>=3.4.0'],


### PR DESCRIPTION
Recently, PacktPub has added the REST API to their site, which caused the application to stop working. This PR adapts the code to the new architecture.

Require refactoring:
- [x] claim free ebook
- [x] my books list
- [x] download files 
- [ ] slack notification
- [ ] pushover notification
- [ ] rewrite tests